### PR TITLE
docs: fix contribute link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ React components for 🌏[Cesium](https://cesium.com/)
 
 ## Contributors
 
-If you want to contribute, see [documentation](https://resium.reearth.com/contribution).
+If you want to contribute, see [documentation](https://resium.reearth.io/contribution).
 
 ### Code Contributors
 


### PR DESCRIPTION
Just realized the contribution documentation link is dead in the README.md file.

Here's a simple fix