### PR TITLE
docs: Fix Typo in Installation Docs

### DIFF
--- a/docs/docs/01-installation.md
+++ b/docs/docs/01-installation.md
@@ -339,10 +339,10 @@ Then install Cesium, Resium, and [vite-plugin-cesium](https://github.com/)
 
 ```bash
 npm install --save cesium resium
-npm install --save-dev vite-plguin-cesium
+npm install --save-dev vite-plugin-cesium
 # OR
 yarn add cesium resium
-yarn add --dev vite-plguin-cesium
+yarn add --dev vite-plugin-cesium
 ```
 
 Then edit `vite.config.js`:


### PR DESCRIPTION
There was a typo in the installation command for vite-plugin-cesium.