### PR TITLE
Fix: Entity Description Props missing Children type

### DIFF
--- a/src/EntityDescription/EntityDescription.ts
+++ b/src/EntityDescription/EntityDescription.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, FC } from "react";
+import { useEffect, useState, useMemo, FC, ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Entity } from "cesium";
 
@@ -22,6 +22,7 @@ and can not be mounted more than once for each entity.
 export type EntityDescriptionProps = {
   container?: Element;
   resizeInfoBox?: boolean;
+  children?: ReactNode;
 };
 
 const EntityDescription: FC<EntityDescriptionProps> = ({


### PR DESCRIPTION
Hi, I found we miss "children" type for Entity Desc Component
![ett](https://user-images.githubusercontent.com/49312359/174209456-abb68fcf-1062-415a-acad-327ec0e4e122.png)

