### PR TITLE
fix: EntityDescription isn't displayed well

### DIFF
--- a/src/EntityDescription/EntityDescription.tsx
+++ b/src/EntityDescription/EntityDescription.tsx
@@ -66,7 +66,7 @@ const EntityDescription: FC<EntityDescriptionProps> = ({
         interval = window.setInterval(() => {
           // wait for infobox to become visible.
           const node = viewer.infoBox.container.querySelector(
-            ".cesium-infoBox.cesium-infoBox-bodyless.cesium-infoBox-visible",
+            ".cesium-infoBox.cesium-infoBox-visible",
           );
 
           if (!node) return;
@@ -78,7 +78,7 @@ const EntityDescription: FC<EntityDescriptionProps> = ({
           // append the description content to infoBox.
           parent.appendChild(c);
 
-          // remove cesium-infoBox-bodyless class
+          // remove cesium-infoBox-bodyless class if it exists on the infobox.
           node.classList.remove("cesium-infoBox-bodyless");
           frame.style.height = parent.getBoundingClientRect().height + "px";
         }, 10);


### PR DESCRIPTION
Removes assumption that the infobox always has the bodyless class.

From looking at the infobox behavior it looks like the bodyless class isn't always present when you click different entities. Removing it fixed the issues detailed in https://github.com/reearth/resium/issues/628

Tested both on my local environment using Resium as well as the story noted in the issue that exhibited similar behavior.

closes #628