### PR TITLE
Fix ImageryLayer readonly imageryProvider prop

### DIFF
--- a/src/ImageryLayer/ImageryLayer.ts
+++ b/src/ImageryLayer/ImageryLayer.ts
@@ -48,7 +48,10 @@ export type Target = Merge<CesiumImageryLayer, ConstructorOptions2<typeof Cesium
 
 export type ImageryLayerCesiumProps = PickCesiumProps<Target, typeof cesiumProps>;
 
-export type ImageryLayerCesiumReadonlyProps = PickCesiumProps<Target, typeof cesiumReadonlyProps>;
+export type ImageryLayerCesiumReadonlyProps = Omit<
+  PickCesiumProps<Target, typeof cesiumReadonlyProps>,
+  "imageryProvider"
+>;
 
 export type ImageryLayerOtherProps = {
   imageryProvider: ImageryProvider | Promise<ImageryProvider>;
@@ -83,9 +86,8 @@ const cesiumReadonlyProps = [
   "minimumTerrainLevel",
   "maximumTerrainLevel",
   "readyEvent",
+  "imageryProvider",
 ] as const;
-
-const otherProps = ["imageryProvider"] as const;
 
 const ImageryLayer = createCesiumComponent<CesiumImageryLayer, ImageryLayerProps>({
   name: "ImageryLayer",
@@ -127,7 +129,6 @@ const ImageryLayer = createCesiumComponent<CesiumImageryLayer, ImageryLayerProps
   },
   cesiumProps,
   cesiumReadonlyProps,
-  otherProps,
 });
 
 export default ImageryLayer;


### PR DESCRIPTION
Fixes lack of `ImageryLayer` recreation on `imageryProvider` prop update by adding it to the `cesiumReadonlyProps` array, which is where it belongs according to the [Cesium](https://cesium.com/learn/cesiumjs/ref-doc/ImageryLayer.html#imageryProvider) and [Resium](https://resium.reearth.io/components/ImageryLayer#cesium-read-only-properties) documentation.

Addresses reearth/resium#664