### PR TITLE
refactor: extract shared destroy helper for primitive collections

### DIFF
--- a/src/BillboardCollection/BillboardCollection.ts
+++ b/src/BillboardCollection/BillboardCollection.ts
@@ -2,7 +2,7 @@ import { BillboardCollection as CesiumBillboardCollection } from "cesium";
 import type { ReactNode } from "react";
 
 import type { PickCesiumProps } from "../core";
-import { createCesiumComponent } from "../core";
+import { createCesiumComponent, destroyPrimitiveCollectionChild } from "../core";
 
 /*
 @summary
@@ -57,14 +57,7 @@ const BillboardCollection = createCesiumComponent<
     context.primitiveCollection.add(element);
     return element;
   },
-  destroy(element, context) {
-    if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
-      context.primitiveCollection.remove(element);
-    }
-    if (!element.isDestroyed()) {
-      element.destroy();
-    }
-  },
+  destroy: destroyPrimitiveCollectionChild,
   provide(element) {
     return {
       billboardCollection: element,

--- a/src/BufferPointCollection/BufferPointCollection.ts
+++ b/src/BufferPointCollection/BufferPointCollection.ts
@@ -5,7 +5,7 @@ import {
 import type { ReactNode } from "react";
 
 import type { PickCesiumProps } from "../core";
-import { createCesiumComponent } from "../core";
+import { createCesiumComponent, destroyPrimitiveCollectionChild } from "../core";
 
 /*
 @summary
@@ -93,14 +93,7 @@ const BufferPointCollection = createCesiumComponent<
     context.primitiveCollection.add(element);
     return element;
   },
-  destroy(element, context) {
-    if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
-      context.primitiveCollection.remove(element);
-    }
-    if (!element.isDestroyed()) {
-      element.destroy();
-    }
-  },
+  destroy: destroyPrimitiveCollectionChild,
   provide(element) {
     return {
       bufferPointCollection: element,

--- a/src/BufferPolygonCollection/BufferPolygonCollection.ts
+++ b/src/BufferPolygonCollection/BufferPolygonCollection.ts
@@ -5,7 +5,7 @@ import {
 import type { ReactNode } from "react";
 
 import type { PickCesiumProps } from "../core";
-import { createCesiumComponent } from "../core";
+import { createCesiumComponent, destroyPrimitiveCollectionChild } from "../core";
 
 /*
 @summary
@@ -115,14 +115,7 @@ const BufferPolygonCollection = createCesiumComponent<
     context.primitiveCollection.add(element);
     return element;
   },
-  destroy(element, context) {
-    if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
-      context.primitiveCollection.remove(element);
-    }
-    if (!element.isDestroyed()) {
-      element.destroy();
-    }
-  },
+  destroy: destroyPrimitiveCollectionChild,
   provide(element) {
     return {
       bufferPolygonCollection: element,

--- a/src/BufferPolylineCollection/BufferPolylineCollection.ts
+++ b/src/BufferPolylineCollection/BufferPolylineCollection.ts
@@ -5,7 +5,7 @@ import {
 import type { ReactNode } from "react";
 
 import type { PickCesiumProps } from "../core";
-import { createCesiumComponent } from "../core";
+import { createCesiumComponent, destroyPrimitiveCollectionChild } from "../core";
 
 /*
 @summary
@@ -87,14 +87,7 @@ const BufferPolylineCollection = createCesiumComponent<
     context.primitiveCollection.add(element);
     return element;
   },
-  destroy(element, context) {
-    if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
-      context.primitiveCollection.remove(element);
-    }
-    if (!element.isDestroyed()) {
-      element.destroy();
-    }
-  },
+  destroy: destroyPrimitiveCollectionChild,
   provide(element) {
     return {
       bufferPolylineCollection: element,

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -39,6 +39,21 @@ export function isDestroyed(d: any) {
   return isDestroyable(d) && d.isDestroyed();
 }
 
+// Removes `element` from `context.primitiveCollection` and destroys it. Guards
+// both steps against the collection/element already being destroyed, since
+// teardown order between a collection and its children is not guaranteed.
+export function destroyPrimitiveCollectionChild<Element extends Destroyable>(
+  element: Element,
+  context: { primitiveCollection?: { isDestroyed(): boolean; remove(primitive?: any): boolean } },
+): void {
+  if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
+    context.primitiveCollection.remove(element);
+  }
+  if (!element.isDestroyed()) {
+    element.destroy();
+  }
+}
+
 export function isPromise<T>(maybePromise: T | Promise<T>): maybePromise is Promise<T> {
   return (
     maybePromise &&

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -1,8 +1,45 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
-import { isPromise } from "./util";
+import { destroyPrimitiveCollectionChild, isPromise } from "./util";
 
 test("isPromise", () => {
   expect(isPromise({})).toBeFalsy();
   expect(isPromise(Promise.resolve(undefined))).toBeTruthy();
+});
+
+test("destroyPrimitiveCollectionChild removes from the collection and destroys the element", () => {
+  const element = { isDestroyed: vi.fn(() => false), destroy: vi.fn() };
+  const primitiveCollection = { isDestroyed: vi.fn(() => false), remove: vi.fn() };
+
+  destroyPrimitiveCollectionChild(element, { primitiveCollection });
+
+  expect(primitiveCollection.remove).toHaveBeenCalledWith(element);
+  expect(element.destroy).toHaveBeenCalled();
+});
+
+test("destroyPrimitiveCollectionChild skips remove when the collection is already destroyed", () => {
+  const element = { isDestroyed: vi.fn(() => false), destroy: vi.fn() };
+  const primitiveCollection = { isDestroyed: vi.fn(() => true), remove: vi.fn() };
+
+  destroyPrimitiveCollectionChild(element, { primitiveCollection });
+
+  expect(primitiveCollection.remove).not.toHaveBeenCalled();
+  expect(element.destroy).toHaveBeenCalled();
+});
+
+test("destroyPrimitiveCollectionChild skips destroy when the element is already destroyed", () => {
+  const element = { isDestroyed: vi.fn(() => true), destroy: vi.fn() };
+  const primitiveCollection = { isDestroyed: vi.fn(() => false), remove: vi.fn() };
+
+  destroyPrimitiveCollectionChild(element, { primitiveCollection });
+
+  expect(primitiveCollection.remove).toHaveBeenCalledWith(element);
+  expect(element.destroy).not.toHaveBeenCalled();
+});
+
+test("destroyPrimitiveCollectionChild is a no-op guard when there is no primitiveCollection", () => {
+  const element = { isDestroyed: vi.fn(() => false), destroy: vi.fn() };
+
+  expect(() => destroyPrimitiveCollectionChild(element, {})).not.toThrow();
+  expect(element.destroy).toHaveBeenCalled();
 });


### PR DESCRIPTION
# Overview

Extracts the duplicated `destroy()` logic shared by `BillboardCollection`, `BufferPointCollection`, `BufferPolygonCollection`, and `BufferPolylineCollection` into a single helper, `destroyPrimitiveCollectionChild`, in `src/core/util.ts`. 
Therefore, no behaviour changed.

## What I've done

- Added `destroyPrimitiveCollectionChild(element, context)` to `src/core/util.ts`, consolidating the "remove from `primitiveCollection`, then destroy `element`, guarding both against already being destroyed" pattern.
- Replaced the identical inline `destroy()` implementations in `BillboardCollection.ts`, `BufferPointCollection.ts`, `BufferPolygonCollection.ts`, and `BufferPolylineCollection.ts` with calls to the new helper.
- Added unit tests for the helper covering all four guard branches (normal destroy, collection already destroyed, element already destroyed, no `primitiveCollection` in context).

## What I haven't done

- No behavior change is intended — `create`/`update`/`provide` and other logic in these components are untouched.
- Did not extend this pattern to other collection-shaped components outside this set (e.g. other Primitive collections); left as a possible follow-up.

## How I tested

- `tsc --noEmit` passes with no errors.
- Added unit tests in `src/core/utils.test.ts` covering the new helper (4 cases).
- Could not run `vitest` locally in this checkout 
    - `node_modules` is missing the platform-specific `@rolldown/binding-darwin-arm64` native binding (known npm optional-dependency bug), unrelated to this change, so the test runner fails to start. Please confirm via CI or after a clean reinstall.

## Which point I want you to review particularly

- Whether `destroyPrimitiveCollectionChild(element, context)`'s shape is a reasonable one to reuse for other Cesium collection components later.
- Whether the extraction is truly behavior-preserving for all 4 call sites (i.e. no component-specific nuance was dropped).

## Memo

- Pulled out of a broader bug-review pass as a standalone, behavior-preserving refactor; unrelated bug fixes (`Fxaa`, `ScreenSpaceEventHandler`) are tracked/PR'd separately.

## Checklist
- [x] The PR title follows Conventional Commits (`refactor: dedupe primitive collection destroy logic`).
- [ ] Linked the related issue(s). <!-- fill in if BUGS.md tracking issue exists -->
- [x] Added or updated tests for the change.
- [ ] Updated the relevant documentation. <!-- no user-facing docs affected -->
- [x] Confirmed the change introduces no code with an unknown or incompatible license.