### PR TITLE
fix(core): stop referencing EventManager by name inside its own body (#806)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,18 @@ export default [
       "react-hooks/preserve-manual-memoization": "off",
     },
   },
+  // Build/tooling scripts run in Node, not the browser. The .mts scripts get
+  // Node's globals via typescript-eslint + tsconfig; plain .mjs does not, so
+  // declare the few it uses rather than pulling in another dependency.
+  {
+    files: ["scripts/**/*.mjs"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        process: "readonly",
+      },
+    },
+  },
   // Override for test files - allow {} type in type tests
   {
     files: ["**/*.test.ts", "**/*.test.tsx"],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc && vite build",
-    "postbuild": "node --input-type=module -e \"await import('./dist/resium.js')\"",
+    "postbuild": "node --input-type=module -e \"await import('./dist/resium.js')\" && node scripts/check-bundle.mjs",
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "type": "tsc",

--- a/scripts/bundle-collisions.mjs
+++ b/scripts/bundle-collisions.mjs
@@ -1,0 +1,48 @@
+// Detects named class expressions in a bundle that shadow an import alias.
+//
+// A class that references itself by name compiles to `X = class e {...}`. If
+// the minifier picks a name already bound to an import, Webpack resolves the
+// self-reference to the import instead of the class — silently `undefined`.
+// That shipped in six releases as a crash on `<Viewer>` mount (#806).
+//
+// Pure functions only, so the CLI in check-bundle.mjs can always run on import
+// without the tests having to guard against its process.exit.
+
+/** Every identifier an import/require is bound to at module scope. */
+export function importAliases(source) {
+  const aliases = new Set();
+  // ESM named: import { a as b, c } from "x"
+  for (const [, names] of source.matchAll(/import\s*\{([^}]*)\}\s*from\s*["'][^"']+["']/g)) {
+    for (const part of names.split(",")) {
+      const name = part.includes(" as ") ? part.split(" as ")[1] : part;
+      if (name.trim()) aliases.add(name.trim());
+    }
+  }
+  // ESM default/namespace: import x from "y" / import * as x from "y"
+  for (const [, name] of source.matchAll(
+    /import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s*(?:,|from)/g,
+  )) {
+    aliases.add(name);
+  }
+  // CJS destructured: const { a: b } = require("x")
+  for (const [, names] of source.matchAll(/(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\(/g)) {
+    for (const part of names.split(",")) {
+      const name = part.includes(":") ? part.split(":")[1] : part;
+      if (name.trim()) aliases.add(name.trim());
+    }
+  }
+  // CJS namespace: let e = require("x"), t = require("y")
+  for (const [, name] of source.matchAll(/([A-Za-z_$][\w$]*)\s*=\s*require\(/g)) {
+    aliases.add(name);
+  }
+  return aliases;
+}
+
+/** Names of named class expressions that shadow an import alias. */
+export function findCollisions(source) {
+  const aliases = importAliases(source);
+  const named = [
+    ...source.matchAll(/=\s*class\s+([A-Za-z_$][\w$]*)\s*(?:extends\s+[^{]+?)?\{/g),
+  ].map(m => m[1]);
+  return [...new Set(named.filter(name => aliases.has(name)))];
+}

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -1,87 +1,43 @@
-// Fails the build if a named class expression shadows an import alias.
+// Fails the build if a bundle contains a named class expression that shadows an
+// import alias — see bundle-collisions.mjs and #806. Run from postbuild.
 //
-// A class that references itself by name compiles to `X = class e {...}`. If
-// the minifier picks a name already bound to an import, Webpack resolves the
-// self-reference to the import instead of the class — silently `undefined`.
-// That shipped in six releases as a crash on `<Viewer>` mount (#806). Source
-// tests can't see it, so assert on the build output.
+// No "am I the entrypoint?" guard on purpose: this file is only ever executed,
+// never imported, and every idiom for that check has a silent-failure mode
+// (percent-encoded paths, Windows separators, symlinked checkouts) that would
+// skip the check while still exiting 0.
 
 import { readFileSync } from "node:fs";
 
-export const BUNDLES = ["dist/resium.js", "dist/resium.cjs"];
+import { findCollisions } from "./bundle-collisions.mjs";
 
-/** Every identifier an import/require is bound to at module scope. */
-export function importAliases(source) {
-  const aliases = new Set();
-  // ESM named: import { a as b, c } from "x"
-  for (const [, names] of source.matchAll(/import\s*\{([^}]*)\}\s*from\s*["'][^"']+["']/g)) {
-    for (const part of names.split(",")) {
-      const name = part.includes(" as ") ? part.split(" as ")[1] : part;
-      if (name.trim()) aliases.add(name.trim());
-    }
+const BUNDLES = ["dist/resium.js", "dist/resium.cjs"];
+
+let failed = false;
+
+for (const bundle of BUNDLES) {
+  let source;
+  try {
+    source = readFileSync(bundle, "utf8");
+  } catch {
+    console.error(`check-bundle: ${bundle} not found — run the build first.`);
+    failed = true;
+    continue;
   }
-  // ESM default/namespace: import x from "y" / import * as x from "y"
-  for (const [, name] of source.matchAll(
-    /import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s*(?:,|from)/g,
-  )) {
-    aliases.add(name);
+
+  const collisions = findCollisions(source);
+  if (collisions.length > 0) {
+    failed = true;
+    console.error(
+      `check-bundle: ${bundle} emits a named class expression whose name collides ` +
+        `with an import alias: ${collisions.map(c => `\`class ${c}\``).join(", ")}.\n` +
+        `  A consumer bundler may resolve the class's self-reference to the import ` +
+        `instead of the class (see issue #806).\n` +
+        `  Fix at the source: stop referencing the class by name inside its own body — ` +
+        `hoist the shared value to a module-level constant.`,
+    );
+  } else {
+    console.log(`check-bundle: ${bundle} ok`);
   }
-  // CJS destructured: const { a: b } = require("x")
-  for (const [, names] of source.matchAll(/(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\(/g)) {
-    for (const part of names.split(",")) {
-      const name = part.includes(":") ? part.split(":")[1] : part;
-      if (name.trim()) aliases.add(name.trim());
-    }
-  }
-  // CJS namespace: let e = require("x"), t = require("y")
-  for (const [, name] of source.matchAll(/([A-Za-z_$][\w$]*)\s*=\s*require\(/g)) {
-    aliases.add(name);
-  }
-  return aliases;
 }
 
-/** Names of named class expressions that shadow an import alias. */
-export function findCollisions(source) {
-  const aliases = importAliases(source);
-  const named = [
-    ...source.matchAll(/=\s*class\s+([A-Za-z_$][\w$]*)\s*(?:extends\s+[^{]+?)?\{/g),
-  ].map(m => m[1]);
-  return [...new Set(named.filter(name => aliases.has(name)))];
-}
-
-function main() {
-  let failed = false;
-
-  for (const bundle of BUNDLES) {
-    let source;
-    try {
-      source = readFileSync(bundle, "utf8");
-    } catch {
-      console.error(`check-bundle: ${bundle} not found — run the build first.`);
-      failed = true;
-      continue;
-    }
-
-    const collisions = findCollisions(source);
-    if (collisions.length > 0) {
-      failed = true;
-      console.error(
-        `check-bundle: ${bundle} emits a named class expression whose name collides ` +
-          `with an import alias: ${collisions.map(c => `\`class ${c}\``).join(", ")}.\n` +
-          `  A consumer bundler may resolve the class's self-reference to the import ` +
-          `instead of the class (see issue #806).\n` +
-          `  Fix at the source: stop referencing the class by name inside its own body — ` +
-          `hoist the shared value to a module-level constant.`,
-      );
-    } else {
-      console.log(`check-bundle: ${bundle} ok`);
-    }
-  }
-
-  if (failed) process.exit(1);
-}
-
-// Only run when invoked as a script, so the helpers stay importable from tests.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
-  main();
-}
+if (failed) process.exit(1);

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -1,21 +1,10 @@
-// Guards against a class of bundler bug that only shows up in consumers.
+// Fails the build if a named class expression shadows an import alias.
 //
-// When a class references itself by name from inside its own body, the bundler
-// preserves that self-reference by emitting a *named class expression*
-// (`X = class e { ... e.foo ... }`). The minifier then picks the shortest free
-// name, which can be one already bound to an import at module scope
-// (`import { createContext as e } from "react"`).
-//
-// Per spec the inner class-name binding shadows the outer import, so the bundle
-// is technically correct — and Vite consumers are fine. But Webpack's import
-// rewriting (Next.js 12) does not honour that shadowing: it rewrites the inner
-// reference to the imported module namespace, and the lookup silently yields
-// `undefined`. In issue #806 this made `<Viewer>` throw "Cannot read properties
-// of undefined (reading 'onClick')" on mount for every consumer on that
-// toolchain, across six releases.
-//
-// The unit tests run against source and so cannot see this, and the bundle is
-// unreadable by eye — hence a direct assertion on the build output.
+// A class that references itself by name compiles to `X = class e {...}`. If
+// the minifier picks a name already bound to an import, Webpack resolves the
+// self-reference to the import instead of the class — silently `undefined`.
+// That shipped in six releases as a crash on `<Viewer>` mount (#806). Source
+// tests can't see it, so assert on the build output.
 
 import { readFileSync } from "node:fs";
 

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -1,0 +1,98 @@
+// Guards against a class of bundler bug that only shows up in consumers.
+//
+// When a class references itself by name from inside its own body, the bundler
+// preserves that self-reference by emitting a *named class expression*
+// (`X = class e { ... e.foo ... }`). The minifier then picks the shortest free
+// name, which can be one already bound to an import at module scope
+// (`import { createContext as e } from "react"`).
+//
+// Per spec the inner class-name binding shadows the outer import, so the bundle
+// is technically correct — and Vite consumers are fine. But Webpack's import
+// rewriting (Next.js 12) does not honour that shadowing: it rewrites the inner
+// reference to the imported module namespace, and the lookup silently yields
+// `undefined`. In issue #806 this made `<Viewer>` throw "Cannot read properties
+// of undefined (reading 'onClick')" on mount for every consumer on that
+// toolchain, across six releases.
+//
+// The unit tests run against source and so cannot see this, and the bundle is
+// unreadable by eye — hence a direct assertion on the build output.
+
+import { readFileSync } from "node:fs";
+
+export const BUNDLES = ["dist/resium.js", "dist/resium.cjs"];
+
+/** Every identifier an import/require is bound to at module scope. */
+export function importAliases(source) {
+  const aliases = new Set();
+  // ESM named: import { a as b, c } from "x"
+  for (const [, names] of source.matchAll(/import\s*\{([^}]*)\}\s*from\s*["'][^"']+["']/g)) {
+    for (const part of names.split(",")) {
+      const name = part.includes(" as ") ? part.split(" as ")[1] : part;
+      if (name.trim()) aliases.add(name.trim());
+    }
+  }
+  // ESM default/namespace: import x from "y" / import * as x from "y"
+  for (const [, name] of source.matchAll(
+    /import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s*(?:,|from)/g,
+  )) {
+    aliases.add(name);
+  }
+  // CJS destructured: const { a: b } = require("x")
+  for (const [, names] of source.matchAll(/(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\(/g)) {
+    for (const part of names.split(",")) {
+      const name = part.includes(":") ? part.split(":")[1] : part;
+      if (name.trim()) aliases.add(name.trim());
+    }
+  }
+  // CJS namespace: let e = require("x"), t = require("y")
+  for (const [, name] of source.matchAll(/([A-Za-z_$][\w$]*)\s*=\s*require\(/g)) {
+    aliases.add(name);
+  }
+  return aliases;
+}
+
+/** Names of named class expressions that shadow an import alias. */
+export function findCollisions(source) {
+  const aliases = importAliases(source);
+  const named = [
+    ...source.matchAll(/=\s*class\s+([A-Za-z_$][\w$]*)\s*(?:extends\s+[^{]+?)?\{/g),
+  ].map(m => m[1]);
+  return [...new Set(named.filter(name => aliases.has(name)))];
+}
+
+function main() {
+  let failed = false;
+
+  for (const bundle of BUNDLES) {
+    let source;
+    try {
+      source = readFileSync(bundle, "utf8");
+    } catch {
+      console.error(`check-bundle: ${bundle} not found — run the build first.`);
+      failed = true;
+      continue;
+    }
+
+    const collisions = findCollisions(source);
+    if (collisions.length > 0) {
+      failed = true;
+      console.error(
+        `check-bundle: ${bundle} emits a named class expression whose name collides ` +
+          `with an import alias: ${collisions.map(c => `\`class ${c}\``).join(", ")}.\n` +
+          `  A consumer bundler may resolve the class's self-reference to the import ` +
+          `instead of the class (see issue #806).\n` +
+          `  Fix at the source: stop referencing the class by name inside its own body — ` +
+          `hoist the shared value to a module-level constant.`,
+      );
+    } else {
+      console.log(`check-bundle: ${bundle} ok`);
+    }
+  }
+
+  if (failed) process.exit(1);
+}
+
+// Only run when invoked as a script, so the helpers stay importable from tests.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/check-bundle.test.ts
+++ b/scripts/check-bundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { findCollisions, importAliases } from "./check-bundle.mjs";
+import { findCollisions, importAliases } from "./bundle-collisions.mjs";
 
 // Fixtures are the real shapes that shipped broken in #806. Without these, a
 // regression in the matching would let the guard pass silently.

--- a/scripts/check-bundle.test.ts
+++ b/scripts/check-bundle.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { findCollisions, importAliases } from "./check-bundle.mjs";
+
+// These fixtures are trimmed from real resium bundles. The ones marked "#806"
+// are the exact shapes that shipped broken across 1.21.1–1.25.0, so if the
+// detection logic ever stops recognising them the guard would silently pass
+// and the bug could ship again.
+describe("importAliases", () => {
+  it("collects ESM named import aliases", () => {
+    const aliases = importAliases(
+      `import { createContext as e, forwardRef as t, useRef as l } from "react"`,
+    );
+    expect(aliases).toContain("e");
+    expect(aliases).toContain("t");
+    expect(aliases).toContain("l");
+  });
+
+  it("collects CJS namespace requires", () => {
+    const aliases = importAliases(`let e=require("react"),t=require("cesium");`);
+    expect(aliases).toContain("e");
+    expect(aliases).toContain("t");
+  });
+
+  it("collects CJS destructured requires", () => {
+    expect(importAliases(`const { useRef: r } = require("react");`)).toContain("r");
+  });
+});
+
+describe("findCollisions", () => {
+  it("flags the ESM shape that shipped in #806", () => {
+    const source = `import { createContext as e } from "react";
+      let Xe = class e { static eventTypeMap = { onClick: 1 }; };`;
+    expect(findCollisions(source)).toEqual(["e"]);
+  });
+
+  it("flags the CJS shape that shipped in #806", () => {
+    const source = `let e=require("react");var v=class e{static eventTypeMap={onClick:1}};`;
+    expect(findCollisions(source)).toEqual(["e"]);
+  });
+
+  it("passes a named class expression that shadows nothing", () => {
+    const source = `import { createContext as e } from "react";
+      let Xe = class Inner { static map = {}; };`;
+    expect(findCollisions(source)).toEqual([]);
+  });
+
+  it("passes the fixed shape — a module-scope constant, no named class", () => {
+    const source = `import { createContext as e } from "react";
+      let Xe = { onClick: 1 }; let Ye = class { commit() { return Xe.onClick; } };`;
+    expect(findCollisions(source)).toEqual([]);
+  });
+
+  it("still flags a collision on a class that extends another", () => {
+    const source = `import { Component as e } from "react";
+      let A = class e extends Base { static m = {}; };`;
+    expect(findCollisions(source)).toEqual(["e"]);
+  });
+});

--- a/scripts/check-bundle.test.ts
+++ b/scripts/check-bundle.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { findCollisions, importAliases } from "./check-bundle.mjs";
 
-// These fixtures are trimmed from real resium bundles. The ones marked "#806"
-// are the exact shapes that shipped broken across 1.21.1–1.25.0, so if the
-// detection logic ever stops recognising them the guard would silently pass
-// and the bug could ship again.
+// Fixtures are the real shapes that shipped broken in #806. Without these, a
+// regression in the matching would let the guard pass silently.
 describe("importAliases", () => {
   it("collects ESM named import aliases", () => {
     const aliases = importAliases(

--- a/src/core/EventManager.ts
+++ b/src/core/EventManager.ts
@@ -103,27 +103,39 @@ export const eventNames: EventType[] = [
   "onMouseLeave",
 ];
 
-export class EventManager {
-  private static eventTypeMap: EventMap<ScreenSpaceEventType> = {
-    onClick: ScreenSpaceEventType.LEFT_CLICK,
-    onDoubleClick: ScreenSpaceEventType.LEFT_DOUBLE_CLICK,
-    onMouseDown: ScreenSpaceEventType.LEFT_DOWN,
-    onMouseUp: ScreenSpaceEventType.LEFT_UP,
-    onMiddleClick: ScreenSpaceEventType.MIDDLE_CLICK,
-    onMiddleDown: ScreenSpaceEventType.MIDDLE_DOWN,
-    onMiddleUp: ScreenSpaceEventType.MIDDLE_UP,
-    onMouseMove: ScreenSpaceEventType.MOUSE_MOVE,
-    onPinchEnd: ScreenSpaceEventType.PINCH_END,
-    onPinchMove: ScreenSpaceEventType.PINCH_MOVE,
-    onPinchStart: ScreenSpaceEventType.PINCH_START,
-    onRightClick: ScreenSpaceEventType.RIGHT_CLICK,
-    onRightDown: ScreenSpaceEventType.RIGHT_DOWN,
-    onRightUp: ScreenSpaceEventType.RIGHT_UP,
-    onWheel: ScreenSpaceEventType.WHEEL,
-    onMouseEnter: ScreenSpaceEventType.MOUSE_MOVE,
-    onMouseLeave: ScreenSpaceEventType.MOUSE_MOVE,
-  };
+// Deliberately a module-level constant rather than a `static` member of
+// EventManager. A `EventManager.eventTypeMap` lookup from inside the class body
+// is a self-reference, which makes the bundler emit a named class expression
+// (`X = class e { ... e.eventTypeMap ... }`). The minifier then picks a name
+// that can collide with an import alias at module scope — `createContext as e`
+// from React, as it happened. Webpack (Next.js 12) does not honour the inner
+// class-name binding when it rewrites imports, so the lookup resolved to the
+// React namespace and `<Viewer>` threw "Cannot read properties of undefined
+// (reading 'onClick')" on mount for every consumer on that toolchain. See #806.
+// A module-level constant removes the self-reference, so no inner class name is
+// emitted and the collision cannot arise. `scripts/check-bundle.mjs` enforces
+// this on the built output.
+const eventTypeMap: EventMap<ScreenSpaceEventType> = {
+  onClick: ScreenSpaceEventType.LEFT_CLICK,
+  onDoubleClick: ScreenSpaceEventType.LEFT_DOUBLE_CLICK,
+  onMouseDown: ScreenSpaceEventType.LEFT_DOWN,
+  onMouseUp: ScreenSpaceEventType.LEFT_UP,
+  onMiddleClick: ScreenSpaceEventType.MIDDLE_CLICK,
+  onMiddleDown: ScreenSpaceEventType.MIDDLE_DOWN,
+  onMiddleUp: ScreenSpaceEventType.MIDDLE_UP,
+  onMouseMove: ScreenSpaceEventType.MOUSE_MOVE,
+  onPinchEnd: ScreenSpaceEventType.PINCH_END,
+  onPinchMove: ScreenSpaceEventType.PINCH_MOVE,
+  onPinchStart: ScreenSpaceEventType.PINCH_START,
+  onRightClick: ScreenSpaceEventType.RIGHT_CLICK,
+  onRightDown: ScreenSpaceEventType.RIGHT_DOWN,
+  onRightUp: ScreenSpaceEventType.RIGHT_UP,
+  onWheel: ScreenSpaceEventType.WHEEL,
+  onMouseEnter: ScreenSpaceEventType.MOUSE_MOVE,
+  onMouseLeave: ScreenSpaceEventType.MOUSE_MOVE,
+};
 
+export class EventManager {
   private scene: Scene | undefined;
   private sshe: ScreenSpaceEventHandler;
   private events: EventMap<Map<any, Callback>> = {
@@ -218,7 +230,7 @@ export class EventManager {
         return;
       }
 
-      const cesiumEventType = EventManager.eventTypeMap[et];
+      const cesiumEventType = eventTypeMap[et];
 
       if (!destroyed) {
         if (m.size === 0) {

--- a/src/core/EventManager.ts
+++ b/src/core/EventManager.ts
@@ -103,18 +103,10 @@ export const eventNames: EventType[] = [
   "onMouseLeave",
 ];
 
-// Deliberately a module-level constant rather than a `static` member of
-// EventManager. A `EventManager.eventTypeMap` lookup from inside the class body
-// is a self-reference, which makes the bundler emit a named class expression
-// (`X = class e { ... e.eventTypeMap ... }`). The minifier then picks a name
-// that can collide with an import alias at module scope — `createContext as e`
-// from React, as it happened. Webpack (Next.js 12) does not honour the inner
-// class-name binding when it rewrites imports, so the lookup resolved to the
-// React namespace and `<Viewer>` threw "Cannot read properties of undefined
-// (reading 'onClick')" on mount for every consumer on that toolchain. See #806.
-// A module-level constant removes the self-reference, so no inner class name is
-// emitted and the collision cannot arise. `scripts/check-bundle.mjs` enforces
-// this on the built output.
+// Module-level, not a `static` member: referencing the class by name from
+// inside its own body makes the bundler emit `class e {...}`, which collided
+// with React's `createContext as e` import and broke Webpack consumers (#806).
+// Enforced by scripts/check-bundle.mjs.
 const eventTypeMap: EventMap<ScreenSpaceEventType> = {
   onClick: ScreenSpaceEventType.LEFT_CLICK,
   onDoubleClick: ScreenSpaceEventType.LEFT_DOUBLE_CLICK,


### PR DESCRIPTION
Fixes #806 — `<Viewer>` crashes on mount for Next.js 12 + Webpack consumers, on every release from 1.21.1 through 1.25.0.

```
TypeError: Cannot read properties of undefined (reading 'onClick')
```

## Root cause

The source was correct. The published bundle was not.

`EventManager.commit()` looked up `EventManager.eventTypeMap[et]` — a reference to the class **by name, from inside the class body**. A bundler preserves that self-reference by emitting a *named class expression*, and the minifier picks the shortest free name. It picked `e`, which was already bound to a React import at module scope:

```js
import { createContext as e, forwardRef as t, ... } from "react"
...
Xe = class e {
  static eventTypeMap = { onClick: R.LEFT_CLICK, ... }
  commit() { ... let a = e.eventTypeMap[r]; ... }
}
```

Per spec the inner class-name binding shadows the outer import, so the bundle is technically valid — which is exactly why Vite consumers never hit this. Webpack's import rewriting in Next 12 does **not** honour that shadowing: it resolves the inner `e` to the React module namespace, `e.eventTypeMap` is `undefined`, and indexing it with `"onClick"` throws.

Credit to the reporter, who traced this to the precise line and confirmed it across five versions and three bundler setups.

I verified the diagnosis against a fresh build of `main` rather than taking it on trust, and scanned the whole bundle: there was **exactly one** named class expression in the output, and it collided. Isolated, not systemic.

## The fix

`eventTypeMap` is a constant lookup table. It was `private static` and read in exactly one place, so it becomes a module-level constant. That removes the self-reference entirely, so no inner class name is emitted and the collision cannot arise.

Both bundles now emit a direct module-scope lookup, and zero named class expressions remain:

| | before | after |
|---|---|---|
| `dist/resium.js` | `let a = e.eventTypeMap[r]` | `let i = Xe[n]` |
| `dist/resium.cjs` | `let a=e.eventTypeMap[t]` | `let i=v[t]` |

## Why the test is a build check, not a unit test

This defect only ever existed in the bundle. The existing `EventManager` tests exercise `commit()` and assert that `LEFT_CLICK` gets registered — they passed throughout, because they run against source. No unit test could have caught it.

So the check goes where the defect lives. `scripts/check-bundle.mjs` fails the build if any named class expression shadows an import alias, and it is wired into `postbuild`. Verified in both directions:

```
BUILD EXIT CODE WITH BUG:   1
BUILD EXIT CODE AFTER FIX:  0
```

The guard's own detection logic is unit-tested against the exact ESM and CJS shapes that shipped broken. That is not ceremony: an earlier revision of the guard silently reported the CJS bundle clean because it only matched destructured `require`s and missed `let e = require("react")`. A guard that quietly stops detecting is worse than no guard, so its logic is now pinned by tests.

## Verification

`npm run lint`, `npm run type` and `npm run build` all clean. 92 test files / 145 tests pass (8 new).

No runtime behaviour changes and no public API changes — `eventTypeMap` was private. VRT should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
